### PR TITLE
Update MC logo to blue gradient background

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -35,7 +35,7 @@
     <div class="min-h-full">
       <header class="sticky top-0 z-30 bg-white/80 backdrop-blur border-b border-gray-200">
         <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-4 flex items-center gap-4">
-          <div class="h-10 w-10 rounded-lg bg-gradient-to-tr from-brand-500 to-red-500 shadow-soft grid place-items-center text-white font-bold">MC</div>
+          <div class="h-10 w-10 rounded-lg bg-gradient-to-tr from-blue-500 to-sky-300 shadow-soft grid place-items-center text-white font-bold">MC</div>
           <div class="flex-1">
             <h1 class="text-lg sm:text-xl font-semibold text-gray-900">Marketing Campaigns</h1>
             <p class="text-sm text-gray-500" id="count">Loading campaigns…</p>
@@ -57,7 +57,7 @@
           <div class="bg-white rounded-2xl shadow-soft ring-1 ring-black/5 overflow-hidden">
             <div class="flex items-center justify-between border-b border-gray-200 p-4">
               <div class="flex items-center gap-3">
-                <div class="h-8 w-8 rounded-md bg-gradient-to-tr from-brand-500 to-red-500 text-white grid place-items-center text-xs font-bold">MC</div>
+                <div class="h-8 w-8 rounded-md bg-gradient-to-tr from-blue-500 to-sky-300 text-white grid place-items-center text-xs font-bold">MC</div>
                 <div>
                   <div id="modal-title" class="text-sm font-semibold text-gray-900">Campaign</div>
                   <div id="modal-subtitle" class="text-xs text-gray-500">Preview of marketing email</div>


### PR DESCRIPTION
## Summary
- switch the MC logo background gradient in the header and modal from orange/red to a softer blue gradient

## Testing
- `npm run start`


------
https://chatgpt.com/codex/tasks/task_i_68b56e5c3d988330ae72334ada99100e