### PR TITLE
Render campaigns dynamically on dashboard

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -173,21 +173,46 @@
           const img = hero?.image?.url || hero?.url || '';
           const title = titleFor(c, i);
           const alt = hero?.alt_text || hero?.name || 'campaign hero';
+          const creativeDirection = textOr(c, 'creative_direction') || 'No creative direction provided.';
+          const ctaText = typeof c.cta === 'string' ? c.cta : (c.cta?.text || '');
+          const ctaHref = typeof c.cta === 'object' ? (c.cta.url || '#') : '#';
+          const assets = Array.isArray(c.assets) ? c.assets.filter(a => (a?.image?.url || a?.url) && !a.error) : [];
+          const assetMarkup = assets.length
+            ? `<div class="mt-4 flex gap-3 overflow-x-auto pb-1">
+                ${assets.slice(0, 4).map(a => `
+                  <img src="${a.image?.url || a.url}" alt="${escapeHtml(a.alt_text || a.name || 'campaign asset')}" class="h-16 w-16 flex-none rounded-lg border border-gray-200 object-cover" />
+                `).join('')}
+                ${assets.length > 4 ? `<span class="text-xs text-gray-500 self-center">+${assets.length - 4} more</span>` : ''}
+              </div>`
+            : `<p class="mt-4 text-xs text-gray-400">No assets provided.</p>`;
+
           return `
-            <button data-index="${i}" class="group text-left bg-white border border-gray-200 rounded-2xl overflow-hidden shadow-sm hover:shadow-md transition-shadow focus:outline-none focus:ring-2 focus:ring-brand-500">
+            <article data-index="${i}" role="button" tabindex="0" aria-label="View campaign ${escapeHtml(title)}" class="group bg-white border border-gray-200 rounded-2xl overflow-hidden shadow-sm hover:shadow-md transition-shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500">
               <div class="aspect-[4/3] bg-gray-100 overflow-hidden">
                 ${img ? `<img src="${img}" alt="${escapeHtml(alt)}" class="h-full w-full object-cover group-hover:scale-[1.02] transition-transform" />` : ''}
               </div>
-              <div class="p-4">
-                <h3 class="text-sm font-semibold text-gray-900 line-clamp-2">${escapeHtml(title)}</h3>
+              <div class="p-4 space-y-3">
+                <h3 class="text-base font-semibold text-gray-900 line-clamp-2">${escapeHtml(title)}</h3>
+                <p class="text-sm text-gray-600 line-clamp-3"><strong class="font-semibold text-gray-800">Creative Direction:</strong> ${escapeHtml(creativeDirection)}</p>
+                ${ctaText ? `<p class="text-sm"><a href="${ctaHref}" class="inline-flex items-center gap-1 text-brand-700 hover:text-brand-900 underline" target="_blank" rel="noopener noreferrer">${escapeHtml(ctaText)}<svg xmlns='http://www.w3.org/2000/svg' class='h-4 w-4' viewBox='0 0 24 24' fill='currentColor'><path d='M14 3h7v7h-2V6.41l-9.29 9.3-1.42-1.42 9.3-9.29H14V3Z'/><path d='M5 5h5V3H3v7h2V5Z'/><path d='M19 19h-5v2h7v-7h-2v5Z'/><path d='M5 19v-5H3v7h7v-2H5Z'/></svg></a></p>` : `<p class="text-sm text-gray-400">No CTA provided.</p>`}
+                ${assetMarkup}
               </div>
-            </button>
+            </article>
           `;
         }).join('');
 
         // Attach click listeners
-        grid.querySelectorAll('button[data-index]').forEach(btn => {
-          btn.addEventListener('click', () => openModal(parseInt(btn.dataset.index, 10)));
+        grid.querySelectorAll('[data-index]').forEach(element => {
+          element.addEventListener('click', (event) => {
+            if (event.target.closest('a')) return;
+            openModal(parseInt(element.dataset.index, 10));
+          });
+          element.addEventListener('keydown', (event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault();
+              openModal(parseInt(element.dataset.index, 10));
+            }
+          });
         });
       }
 


### PR DESCRIPTION
## Summary
- fetch `/campaigns.json` on page load and populate the dashboard grid
- show campaign creative direction, CTA link, and asset thumbnails in each card
- allow keyboard and mouse interactions to open the detailed modal without triggering from CTA links

## Testing
- npm run start


------
https://chatgpt.com/codex/tasks/task_i_68b57b4c93dc8330b457b7f950bea1cf