### PR TITLE
Add in-memory campaign persistence option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Marketing Campaign Image Generator
+
+This project exposes an API and gallery for generating marketing campaign imagery.
+
+## Campaign persistence
+
+Campaigns are stored on the local filesystem by default. When running in environments where persistent storage is unavailable, set the `IN_MEMORY_CAMPAIGNS` environment variable to keep campaigns in memory instead. In-memory data is lost whenever the instance experiences a cold start or scales down.

--- a/index.js
+++ b/index.js
@@ -19,10 +19,15 @@ const UPLOADS_ROOT = process.env.UPLOADS_DIR || (process.env.IMAGES_DIR ? path.d
 const IMAGES_DIR = process.env.IMAGES_DIR || path.join(UPLOADS_ROOT, 'images');
 const PUBLIC_IMAGES_DIR = path.join(PUBLIC_DIR, 'images');
 const CAMPAIGNS_FILE = process.env.CAMPAIGNS_FILE || path.join(UPLOADS_ROOT, 'campaigns.json');
+const USE_MEMORY_CAMPAIGNS = Boolean(process.env.IN_MEMORY_CAMPAIGNS);
+let memoryCampaigns = [];
 
 // Filesystem campaign store helpers (Render/local)
 // Persist campaigns at CAMPAIGNS_FILE in the shape: { data: [...] }
 async function readCampaignsList() {
+  if (USE_MEMORY_CAMPAIGNS) {
+    return memoryCampaigns;
+  }
   try {
     const raw = await fs.readFile(CAMPAIGNS_FILE, 'utf8');
     const json = JSON.parse(raw);
@@ -41,6 +46,11 @@ async function readCampaignsList() {
 }
 
 async function writeCampaignsList(list) {
+  if (USE_MEMORY_CAMPAIGNS) {
+    memoryCampaigns = Array.isArray(list) ? [...list] : [];
+    log('Campaigns stored in memory (IN_MEMORY_CAMPAIGNS enabled).');
+    return memoryCampaigns;
+  }
   const dir = path.dirname(CAMPAIGNS_FILE);
   if (!fssync.existsSync(dir)) fssync.mkdirSync(dir, { recursive: true });
   await fs.writeFile(CAMPAIGNS_FILE, JSON.stringify({ data: list }, null, 2), 'utf8');


### PR DESCRIPTION
## Summary
- add an optional in-memory store for campaigns controlled by the `IN_MEMORY_CAMPAIGNS` environment variable
- reuse the existing read/write helpers so the `/campaigns.json` and `/create-campaign` endpoints benefit automatically
- document that in-memory persistence only lasts while a serverless instance stays warm

## Testing
- npm run test (fails: Error: no test specified)

------
https://chatgpt.com/codex/tasks/task_i_68b584e986b88330879772abed00475f